### PR TITLE
 6 arithmetic syntax error in entrypointsh when no version tag exists #11 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,17 +5,22 @@ readonly VERSION=${TAG##*/}
 
 PACKAGE=${INPUT_IMPORT_PATH:=github.com/${GITHUB_REPOSITORY}}
 
-# submodules version tags are formatted as <submodule>/vX.Y.Z,
+# Submodules version tags are formatted as <submodule>/vX.Y.Z,
 # so we extract the submodule name and append it to the main module
 # import path
-if [[ "$VERSION" != "$TAG" ]]; then
+if [ "$VERSION" != "$TAG" ]; then
   PACKAGE=${PACKAGE}/${TAG%"/$VERSION"}
 fi
 
-# if version > 1, then add the version scope
+# If either check fails, the version scoping logic (adding /vX to the package path) 
+# is skipped, preventing the arithmetic error
 readonly MAJOR_VERSION="$(printf '%s' "$VERSION" | cut -d '.' -f 1 | sed 's/v//g')"
-if [ $((10#${MAJOR_VERSION})) -gt 1 ]; then
-  PACKAGE="$PACKAGE/v$MAJOR_VERSION"
+# [ -n "$MAJOR_VERSION" ] check ensures MAJOR_VERSION is not empty
+# grep -q '^[0-9]\+$' check ensures MAJOR_VERSION is numeric (contains only digits)
+if [ -n "$MAJOR_VERSION" ] && echo "$MAJOR_VERSION" | grep -q '^[0-9]\+$'; then
+  if [ $((10#${MAJOR_VERSION})) -gt 1 ]; then
+    PACKAGE="$PACKAGE/v$MAJOR_VERSION"
+  fi
 fi
 
 export GO111MODULE=on


### PR DESCRIPTION
Fix the entrypoint.sh script to handle cases where `VERSION `or `MAJOR_VERSION` is empty or non-numeric.
Adds validation to skip the version scoping logic if no valid version tag is present.