### PR TITLE
Fix entrypoint execution and POSIX compliance issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.25-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2020 Andrey Slotin and contributors
-Copyright (c) 2025 Nicholas Fedor
+Copyright (c) 2025 - 2026 Nicholas Fedor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ on:
   release:
     types:
       - created
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - '**/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   update-proxy-cache:
@@ -120,9 +117,6 @@ on:
   release:
     types:
       - created
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - '**/v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   update-proxy-cache:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
-#!/env/bin/bash
+#!/bin/sh
 
-readonly TAG=${GITHUB_REF#refs/tags/*}
-readonly VERSION=${TAG##*/}
+readonly TAG="${GITHUB_REF#refs/tags/*}"
+readonly VERSION="${TAG##*/}"
 
 PACKAGE=${INPUT_IMPORT_PATH:=github.com/${GITHUB_REPOSITORY}}
 
@@ -19,7 +19,12 @@ readonly MAJOR_VERSION
 # [ -n "$MAJOR_VERSION" ] check ensures MAJOR_VERSION is not empty
 # grep -q '^[0-9]\+$' check ensures MAJOR_VERSION is numeric (contains only digits)
 if [ -n "$MAJOR_VERSION" ] && echo "$MAJOR_VERSION" | grep -q '^[0-9]\+$'; then
-  if [ $((10#${MAJOR_VERSION})) -gt 1 ]; then
+  # Remove leading zeros to avoid octal interpretation in POSIX sh arithmetic
+  DECIMAL_VERSION="$(printf '%s' "$MAJOR_VERSION" | sed 's/^0*//')"
+  # Handle case where MAJOR_VERSION was all zeros
+  [ -z "$DECIMAL_VERSION" ] && DECIMAL_VERSION="0"
+  
+  if [ "$DECIMAL_VERSION" -gt 1 ]; then
     PACKAGE="$PACKAGE/v$MAJOR_VERSION"
   fi
 fi


### PR DESCRIPTION
This fix resolves the "exec /entrypoint.sh: no such file or directory" error that was preventing the GitHub Action from running properly. Additionally, it fixes a ShellCheck SC3052 warning about undefined arithmetic base conversion in POSIX sh.

## Problem

- GitHub Action was failing with "exec /entrypoint.sh: no such file or directory" error
- ShellCheck SC3052 error: "In POSIX sh, arithmetic base conversion is undefined"
- Missing executable permissions on entrypoint.sh in Dockerfile

## Solution

- Fixed shebang from `#!/env/bin/bash` to `#!/bin/sh` for Alpine Linux compatibility
- Added `RUN chmod +x /entrypoint.sh` in Dockerfile for proper permissions
- Replaced problematic `$((10#${MAJOR_VERSION}))` arithmetic with POSIX-compliant string manipulation
- Improved README documentation with comprehensive examples

## Changes

- **Dockerfile**: Added executable permission for entrypoint.sh
- **entrypoint.sh**: Fixed shebang and POSIX-compliant arithmetic operations
- **LICENSE**: Updated copyright year to 2025-2026
- **README.md**: Complete rewrite with improved structure and examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote README into a full "Go Proxy Cache Updater Action" guide with features, usage, inputs, examples, supported tag formats, and contribution/license sections.

* **Chores**
  * Updated copyright year range to 2025–2026.
  * Improved entrypoint reliability and POSIX compatibility; ensured the entrypoint is executable for consistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->